### PR TITLE
Bug/issue squats image #170

### DIFF
--- a/src/DB/exerciseData.json
+++ b/src/DB/exerciseData.json
@@ -107,7 +107,7 @@
     ],
     "videoLink": "https://www.youtube.com/watch?v=gsNoPYwWXeM",
     "gh-name": "SaswataH",
-    "image": "https://blog.enarahealth.com/wp-content/uploads/2022/03/PngItem_2810409-e1647565708516.png"
+    "image": "https://enarahealth.com/wp-content/uploads/2022/03/PngItem_2810409-e1647565708516.png"
   },
   {
     "exercise": "Dumbbell rows",

--- a/src/DB/exerciseData.json
+++ b/src/DB/exerciseData.json
@@ -451,5 +451,37 @@
     "videoLink": "https://www.youtube.com/watch?v=VJyLJAGjptA",
     "gh-name": "simon1re",
     "image": "https://fitnessprogramer.com/wp-content/uploads/2023/03/Behind-The-Back-Barbell-Shrug-Reverse-Barbell-Shrug.gif"
+  },
+
+  {
+    "exercise": "Dumbbell Bicep Curl",
+    "instructions": [
+    "Stand up straight with a dumbbell in each hand at arm's length.",
+    "Keep your elbows close to your torso at all times.",
+    "Now, keeping the upper arms stationary, exhale and curl the weights while contracting your biceps.",
+    "Continue to raise the weights until your biceps are fully contracted and the dumbbells are at shoulder level.",
+    "Hold the contracted position for a brief moment as you squeeze your biceps.",
+    "Then inhale and slowly begin to lower the dumbbells back to the starting position.",
+    "Repeat for the recommended amount of repetitions."
+    ],
+    "videoLink": "https://www.youtube.com/watch?v=ykJmrZ5v0Oo&ab_channel=Howcast",
+    "gh-name": "CedricNdong",
+    "image": "https://homeworkouts.org/wp-content/uploads/anim-dumbbell-bicep-curls.gif"
+  },
+
+  {
+    "exercise": "Half Crunches",
+    "instructions": [
+    "Begin by lying down on your back.",
+    "Bend your knees and place your feet flat on the floor, hip-width apart.",
+    "Place your hands behind your head, keeping your elbows wide. You can also cross your arms over your chest if you prefer.",
+    "Engage your core and lift your upper body up, stopping halfway between the floor and a full sit-up position. Be sure to keep your lower back, hips, and feet on the floor.",
+    "Pause for a moment, feeling the contraction in your abdominal muscles.",
+    "Slowly lower your upper body back down to the starting position.",
+    "Repeat the movement for the desired number of repetitions."
+    ],
+    "videoLink": "https://www.youtube.com/watch?v=Xyd_fa5zoEU&t=86s&ab_channel=LIVESTRONG.COM",
+    "gh-name": "CedricNdong",
+    "image": "https://fitnessprogramer.com/wp-content/uploads/2015/11/Crunch.gif"
   }
 ]


### PR DESCRIPTION
Absolutely, here's the completed version:

I recently faced a problem while trying to access an image via a provided URL. Instead of displaying the image, I received a "Connection timed out" error. This indicated that there could be a resource-intensive process on the server where the image was hosted.

The image originated from a blog, so to troubleshoot, I navigated to the original website to determine whether the blog had been deleted. The image URL included the date of the blog post, which helped me identify the corresponding blog entry on the website.

Upon reaching the site, I discovered a change in its structure. While earlier each blog post was hosted on a separate page, the website now utilized a Single-Page Application (SPA) model, meaning the blog posts were organized into sections, not individual pages.

Moreover, the blog had been relocated on the website. Instead of being accessible at https://blog.enarahealth.com/, the blog was now available at https://enarahealth.com/blog/. This change in the URL structure was likely the root cause of the issue with the image URL. Consequently, the image link was broken because the original page hosting it no longer existed in its previous form.