### PR TITLE
fix: Center the Navbar for smaller devices

### DIFF
--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -25,7 +25,7 @@ export default function Navbar() {
         ></img>
       </a>
 
-      <ul className='flex flex-wrap items-center gap-2 text-[1rem]'>
+      <ul className='flex flex-wrap items-center justify-center gap-2 text-[1rem]'>
         <li>
           <NavLink
             to='/GuidePage'


### PR DESCRIPTION
This fix aligns the Navbar at the center for smaller devices to improve the appearance.

Fixes Issue #183 

Preview before fix:
![preview-before](https://github.com/gabrysia694/Gym-Junkies/assets/108147735/d23ec2e7-4760-4016-9e27-b0d0ac7f2698)

Preview after fix:
![preview-after](https://github.com/gabrysia694/Gym-Junkies/assets/108147735/1ed8af55-829c-4ebf-982d-edc5b65216a5)
