### PR TITLE
Added github link to contribution text 

### DIFF
--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { FaGithub } from 'react-icons/fa';
+import React from "react";
+import { FaGithub } from "react-icons/fa";
 
 export default function Footer() {
   return (
@@ -14,7 +14,15 @@ export default function Footer() {
             Gym Junkies is an open source project.
           </p>
           <p className='max-w-sm mx-auto mt-0 text-gray-400'>
-            Feel free to contribute to the project.
+            Feel free to{" "}
+            <a
+              className='text-white underline decoration-transparent transition ease-in-out hover:decoration-inherit'
+              href='https://github.com/gabrysia694/Gym-Junkies'
+              target='_blank'
+            >
+              contribute to the project
+            </a>
+            .
           </p>
         </div>
 


### PR DESCRIPTION
Hello Gym Junkies team :)

This fixes issue:  #174

Added a link to the github repo on the Footer contribution text, and also made the link have white text, and underlined on hover.

Now it looks like this:

![image](https://github.com/gabrysia694/Gym-Junkies/assets/4129325/481b6164-ff96-49ec-9c69-28038842004e)


And on hover:

![image](https://github.com/gabrysia694/Gym-Junkies/assets/4129325/f1590b26-1443-44df-8eef-8cf2cd9779b3)
