### PR TITLE
Exercise Cards and Schedule Pages with Night Mode

### DIFF
--- a/src/components/Card.jsx
+++ b/src/components/Card.jsx
@@ -1,48 +1,88 @@
-import React from "react";
+import React, { useContext } from "react";
+import { ThemeContext } from "../context/theme";
+
 import jsonData from "../DB/exerciseData.json";
+import clsx from "clsx";
 
 export default function Card() {
+  const { themeName } = useContext(ThemeContext);
+  console.log(themeName);
   return (
-    <div className="grid grid-cols-1 lg:grid-cols-2 p-3">
+    <div className='grid grid-cols-1 lg:grid-cols-2 p-3'>
       {jsonData.map((exercise, index) => (
         <div
           key={index}
-          className=" max-w-md mx-auto my-4 bg-white rounded-xl shadow-md overflow-hidden md:max-w-2xl hover:border-purple-500 border-2"
+          className={clsx(
+            "max-w-md mx-auto my-4 rounded-xl shadow-md overflow-hidden md:max-w-2xl hover:border-purple-500 border-2",
+            themeName === "light" ? "bg-gray-800" : "bg-white"
+          )}
         >
-          <div className="md:flex items-center  ">
-            <img
-              className="w-64 object-cover h-full md:w-48"
-              loading="lazy"
-              src={exercise.image}
-              alt={exercise.exercise}
-            />
-            <div className="p-8">
-              <div className="uppercase tracking-wide text-sm text-indigo-800 font-semibold">
+          <div className='md:flex items-center'>
+            <div className='p-2 w-full'>
+              <img
+                className={clsx(
+                  "w-64 object-cover h-full md:w-48 bg-white border-2",
+                  themeName === "light"
+                    ? "border-indigo-400 rounded-xl"
+                    : "border-white"
+                )}
+                loading='lazy'
+                src={exercise.image}
+                alt={exercise.exercise}
+              />
+            </div>
+
+            <div className='p-8'>
+              <div
+                className={clsx(
+                  "uppercase italic tracking-wide text-xl font-semibold",
+                  themeName === "light" ? "text-indigo-400" : "text-indigo-800"
+                )}
+              >
                 {exercise.exercise}
               </div>
-              <div style={{ overflowY: 'auto', height: '30vh' }}>
-                <ul className="p-2 text-gray-500 list-disc">
+              <div style={{ overflowY: "auto", height: "30vh" }}>
+                <ul
+                  className={clsx(
+                    "p-2 list-dis",
+                    themeName === "light" ? "text-white-500" : "text-gray-500"
+                  )}
+                >
                   {exercise.instructions.map((instruction, index) => (
                     <li key={index}>{instruction}</li>
                   ))}
                 </ul>
               </div>
-              <div className="mt-6 gap-5 flex items-center">
+              <div className='mt-6 gap-5 flex items-center'>
                 <a
                   href={exercise.videoLink}
-                  target="_blank"
-                  rel="noreferrer"
-                  className="text-indigo-800 hover:text-indigo-600 font-semibold"
+                  target='_blank'
+                  rel='noreferrer'
+                  className={clsx(
+                    "hover:text-indigo-600 font-semibold",
+                    themeName === "light"
+                      ? "text-indigo-400"
+                      : "text-indigo-800"
+                  )}
                 >
                   Watch video
                 </a>
-                <span className="text-black">
+                <span
+                  className={clsx(
+                    themeName === "light" ? "text-white" : "text-black"
+                  )}
+                >
                   Added by :{" "}
                   <a
                     href={`https://github.com/${exercise["gh-name"]}`}
-                    target="_blank"
-                    rel="noreferrer"
-                    className="text-indigo-800 hover:text-indigo-600 font-semibold"
+                    target='_blank'
+                    rel='noreferrer'
+                    className={clsx(
+                      themeName === "light"
+                        ? "text-indigo-400"
+                        : "text-indigo-800",
+                      "hover:text-indigo-600 font-semibol"
+                    )}
                   >
                     {exercise["gh-name"]}
                   </a>

--- a/src/components/Card.jsx
+++ b/src/components/Card.jsx
@@ -18,10 +18,10 @@ export default function Card() {
           )}
         >
           <div className='md:flex items-center'>
-            <div className='p-2 w-full'>
+            <div className='p-4  w-4/6 mx-auto md:w-3/6'>
               <img
                 className={clsx(
-                  "w-64 object-cover h-full md:w-48 bg-white border-2",
+                  "object-cover h-full mx-auto md:w-full bg-white border-2",
                   themeName === "light"
                     ? "border-indigo-400 rounded-xl"
                     : "border-white"
@@ -32,7 +32,7 @@ export default function Card() {
               />
             </div>
 
-            <div className='p-8'>
+            <div className='p-4 w-full md:w-3/6'>
               <div
                 className={clsx(
                   "uppercase italic tracking-wide text-xl font-semibold",

--- a/src/components/Card.jsx
+++ b/src/components/Card.jsx
@@ -6,7 +6,7 @@ import clsx from "clsx";
 
 export default function Card() {
   const { themeName } = useContext(ThemeContext);
-  console.log(themeName);
+
   return (
     <div className='grid grid-cols-1 lg:grid-cols-2 p-3'>
       {jsonData.map((exercise, index) => (

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { FaGithub } from 'react-icons/fa';
+import React from "react";
+import { FaGithub } from "react-icons/fa";
 
 export default function Footer() {
   return (
@@ -14,7 +14,15 @@ export default function Footer() {
             Gym Junkies is an open source project.
           </p>
           <p className='max-w-sm mx-auto mt-0 text-gray-400'>
-            Feel free to contribute to the project.
+            Feel free to{" "}
+            <a
+              className='text-white underline decoration-transparent transition ease-in-out hover:decoration-inherit'
+              href='https://github.com/gabrysia694/Gym-Junkies'
+              target='_blank'
+            >
+              contribute to the project
+            </a>
+            .
           </p>
         </div>
 

--- a/src/pages/SchedulePage.jsx
+++ b/src/pages/SchedulePage.jsx
@@ -1,7 +1,11 @@
-import React from 'react';
-import categoriesData from '../DB/categoriesData.json';
+import React, { useContext } from "react";
+import { ThemeContext } from "../context/theme";
+
+import categoriesData from "../DB/categoriesData.json";
+import clsx from "clsx";
 
 const SchedulePage = () => {
+  const { themeName } = useContext(ThemeContext);
   return (
     <section>
       <div className='flex flex-col mx-auto max-w-screen-xl p-5'>
@@ -12,7 +16,10 @@ const SchedulePage = () => {
         {categoriesData.map((category) => (
           <div
             key={category.id}
-            className='max-w-md mx-auto my-4 bg-white rounded-xl shadow-md overflow-hidden md:max-w-2xl hover:border-purple-500 border-2'
+            className={clsx(
+              "max-w-md mx-auto my-4 rounded-xl shadow-md overflow-hidden md:max-w-2xl hover:border-purple-500 border-2",
+              themeName === "light" ? "bg-gray-800" : "bg-white"
+            )}
           >
             <div className=' md:flex items-center h-full'>
               <img
@@ -22,10 +29,22 @@ const SchedulePage = () => {
                 alt={category.categoryName}
               />
               <div className='p-8'>
-                <div className='uppercase tracking-wide text-lg text-indigo-800 font-semibold'>
+                <div
+                  className={clsx(
+                    "uppercase italic tracking-wide text-lg font-semibold",
+                    themeName === "light"
+                      ? "text-indigo-400"
+                      : "text-indigo-800"
+                  )}
+                >
                   {category.categoryName}
                 </div>
-                <div className=' text-gray-500 ' style={{ height: '20vh' }}>
+                <div
+                  className={clsx(
+                    themeName === "light" ? "text-white-500" : "text-gray-500"
+                  )}
+                  style={{ height: "20vh" }}
+                >
                   {category.description}
                 </div>
               </div>


### PR DESCRIPTION
These changes fixes #178

I updated Card.jsx and SchedulePage.jsx to change styling depending on themeName.

I also made the exercises and schedule names italic.

This is how it looks now on dark mode for exercise cards:

![image](https://github.com/gabrysia694/Gym-Junkies/assets/4129325/dc8ce5c7-0c78-4721-b1d9-bf9c88c97d06)

And this is how  it looks like now on dark mode for schedules:

![image](https://github.com/gabrysia694/Gym-Junkies/assets/4129325/9d577eb6-cb4a-42b1-9629-fa1984620466)

