### PR TITLE
Navbar bug fixed and made it sticky in mobile devices

### DIFF
--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -2,6 +2,8 @@ import React, { useState, useContext } from "react";
 import { ThemeContext } from "../context/theme";
 import { NavLink } from "react-router-dom";
 import clsx from "clsx";
+import { useRef } from "react";
+import { useEffect } from "react";
 
 function navLinkClass(isActive, theme) {
   return clsx(
@@ -17,90 +19,121 @@ export default function Navbar() {
   const { theme, toggleTheme } = useContext(ThemeContext);
   const [navbarShown, setNavbarShown] = useState(false);
 
+  // To make the navbar (in mobile view) get hidden when the user clicks/scroll outside it...
+  const navbarRef = useRef(null);
+
+  useEffect(() => {
+    function handleMouseDown(event) {
+      if (
+        navbarShown &&
+        navbarRef.current &&
+        !navbarRef.current.contains(event.target)
+      ) {
+        setNavbarShown(!false);
+        console.log("outside");
+      }
+    }
+    function handleScroll() {
+      if (navbarShown) {
+        setNavbarShown(false);
+      }
+    }
+
+    document.addEventListener("mousedown", handleMouseDown);
+    document.addEventListener("scroll", handleScroll);
+
+    return () => {
+      document.removeEventListener("mousedown", handleMouseDown);
+      document.removeEventListener("scroll", handleScroll);
+    };
+  }, [navbarShown]);
+  //
+
   const toggleNavbar = () => {
     setNavbarShown(!navbarShown);
   };
 
   return (
     <nav
-      aria-label='Site Nav'
-      className='flex items-center justify-between max-w-8xl p-4 mx-auto'
+      aria-label="Site Nav"
+      className="flex items-center justify-between max-w-8xl p-4 mx-auto sticky top-0 bg-white z-10 border-b drop-shadow-sm"
     >
-      <a href='/'>
+      <a href="/">
         <img
-          src='https://user-images.githubusercontent.com/88102392/233238344-b05e3c5d-178e-4a7b-9757-60063fb0f969.png'
-          className='inline-flex h-[1] w-10 items-center justify-center rounded-lg' // don't change logo's height and width here
-          alt='Gym Junkies logo'
-          loading='lazy'  
+          src="https://user-images.githubusercontent.com/88102392/233238344-b05e3c5d-178e-4a7b-9757-60063fb0f969.png"
+          className="inline-flex h-[1] w-10 items-center justify-center rounded-lg" // don't change logo's height and width here
+          alt="Gym Junkies logo"
+          loading="lazy"
         ></img>
       </a>
 
       <ul
+        ref={navbarRef}
         // className='flex flex-wrap items-center justify-center gap-2 text-[1rem]'
         className={clsx(
           `fixed sm:static top-20 z-10 gap-2 text-md w-full sm:flex flex-wrap items-center justify-center nav-menu`,
-          theme.background === '#fff' ? 'bg-white' : 'bg-black',
-          navbarShown ? 'navbar-shown' : 'navbar-hidden'
+          theme.background === "#fff" ? "bg-white" : "bg-black",
+          navbarShown ? "navbar-shown" : "navbar-hidden"
         )}
         onClick={toggleNavbar}
       >
-        <li className='mb-4 sm:mb-0 sm:ml-8 nav-item text-center'>
+        <li className="mb-4 sm:mb-0 sm:ml-8 nav-item text-center">
           <NavLink
-            to='/GuidePage'
+            to="/GuidePage"
             className={({ isActive }) => navLinkClass(isActive, theme)}
           >
             Guide
           </NavLink>
         </li>
-        <li className='mb-4 sm:mb-0 sm:ml-8 nav-item text-center'>
+        <li className="mb-4 sm:mb-0 sm:ml-8 nav-item text-center">
           <NavLink
-            to='/SchedulePage'
+            to="/SchedulePage"
             className={({ isActive }) => navLinkClass(isActive, theme)}
           >
             Schedule
           </NavLink>
         </li>
-        <li className='mb-4 sm:mb-0 sm:ml-8 nav-item text-center'>
+        <li className="mb-4 sm:mb-0 sm:ml-8 nav-item text-center">
           <NavLink
             className={({ isActive }) => navLinkClass(isActive, theme)}
-            to='/DocsPage'
+            to="/DocsPage"
           >
             Docs
           </NavLink>
         </li>
-        <li className='mb-4 sm:mb-0 sm:ml-8 nav-item text-center'>
+        <li className="mb-4 sm:mb-0 sm:ml-8 nav-item text-center">
           <NavLink
             className={({ isActive }) => navLinkClass(isActive, theme)}
-            to='/ContributorsPage'
+            to="/ContributorsPage"
           >
             Contributors
           </NavLink>
         </li>
       </ul>
-      <button onClick={toggleTheme} className='text-2xl'>
+      <button onClick={toggleTheme} className="text-2xl">
         {theme.icon}
       </button>
 
       <div
-        className={clsx('hamburger', navbarShown && 'active')}
+        className={clsx("hamburger", navbarShown && "active")}
         onClick={toggleNavbar}
       >
         <span
           className={clsx(
-            'bar',
-            theme.background === '#fff' ? 'bg-black' : 'bg-white'
+            "bar",
+            theme.background === "#fff" ? "bg-black" : "bg-white"
           )}
         ></span>
         <span
           className={clsx(
-            'bar',
-            theme.background === '#fff' ? 'bg-black' : 'bg-white'
+            "bar",
+            theme.background === "#fff" ? "bg-black" : "bg-white"
           )}
         ></span>
         <span
           className={clsx(
-            'bar',
-            theme.background === '#fff' ? 'bg-black' : 'bg-white'
+            "bar",
+            theme.background === "#fff" ? "bg-black" : "bg-white"
           )}
         ></span>
       </div>


### PR DESCRIPTION
# issue #244  fixed. 
Bug-> when navigation menu was toggled on on mobile devices, and when the page was scrolled, the navigation bar remains fixed at the top of the screen and close icon gets disappeared.

This one is fixed and navigation bar is made sticky for better user experience.

Problem:
![problem](https://github.com/gabrysia694/Gym-Junkies/assets/134498717/6b5e59a0-6ba2-4c81-997f-a4c2a5031e24)

After fix:
![after fix](https://github.com/gabrysia694/Gym-Junkies/assets/134498717/eaa53522-2b1c-43cd-b493-26006a5e576d)   ![Annotation 2023-08-03 105401](https://github.com/gabrysia694/Gym-Junkies/assets/134498717/a494c1ea-b70d-42f0-a9ae-b2e5e6fa7c7c)

